### PR TITLE
Customized vni settings

### DIFF
--- a/mizar/common/constants.py
+++ b/mizar/common/constants.py
@@ -63,6 +63,7 @@ class OBJ_STATUS:
     vpc_status_allocated = 'Alloc'
     vpc_status_ready = 'Ready'
     vpc_status_provisioned = obj_provisioned
+    vpc_status_error = 'Error'
 
     droplet_status_init = obj_init
     droplet_status_allocated = 'Alloc'
@@ -86,11 +87,9 @@ class OBJ_STATUS:
 
 class OBJ_DEFAULTS:
     default_ep_vpc = 'vpc0'
-    default_ep_vpc1 = 'vpc1'
     default_ep_net = 'net0'
     default_ep_type = 'simple'
     default_vpc_vni = '1'
-    default_vpc_vni1 = '2'
     default_vpc_ip = '20.0.0.0'
     default_vpc_prefix = '8'
     default_net_ip = '20.0.0.0'

--- a/mizar/dp/mizar/operators/vpcs/vpcs_operator.py
+++ b/mizar/dp/mizar/operators/vpcs/vpcs_operator.py
@@ -50,13 +50,14 @@ class VpcOperator(object):
 
     def query_existing_vpcs(self):
         def list_vpc_obj_fn(name, spec, plurals):
-            logger.info("Bootstrapped {}".format(name))
+            #logger.info("Bootstrapped {} with vni {} with status {}".format(name, v.vni, v.status))
             v = self.get_vpc_stored_obj(name, spec)
+            logger.info("Bootstrapped {} with vni {} with status {}".format(name, v.vni, v.status))
             if v.status == OBJ_STATUS.vpc_status_provisioned:
                 self.store_update(v)
 
         kube_list_obj(self.obj_api, RESOURCES.vpcs, list_vpc_obj_fn)
-        logger.debug("Bootstrap VPC store: {}".format(self.store._dump_vpcs()))
+        logger.info("Bootstrap VPC store: {}".format(self.store._dump_vpcs()))
 
     def get_vpc_tmp_obj(self, name, spec):
         return Vpc(name, self.obj_api, None, spec)
@@ -124,6 +125,12 @@ class VpcOperator(object):
         logger.info("The current vpc is {} and the vni is {}".format(vpc.name, vpc.vni))
         if vpc.vni is None:
             vpc.set_vni(str(uuid.uuid4().int & (1 << 24)-1))
+        else:
+            stored_vpcs = self.obj_api.list_cluster_custom_object(group="mizar.com", version="v1", plural="vpcs")
+            for stored_vpc in stored_vpcs["items"]:
+                if stored_vpc["spec"]["vni"] == vpc.vni and stored_vpc["metadata"]["name"] != vpc.name:
+                    vpc.set_vni(str(uuid.uuid4().int & (1 << 24)-1))
+                    logger.info("There is a duplicate vni {} and it has been changed to a new one.".format(stored_vpc["spec"]["vni"], vpc.vni))
         logger.info("The updated vni is {}".format(vpc.vni))
     
     def deallocate_vni(self, vpc):

--- a/mizar/dp/mizar/operators/vpcs/vpcs_operator.py
+++ b/mizar/dp/mizar/operators/vpcs/vpcs_operator.py
@@ -121,10 +121,8 @@ class VpcOperator(object):
         # TODO: There is a tiny chance of collision here, not to worry about now
         if vpc.name == OBJ_DEFAULTS.default_ep_vpc:
             return OBJ_DEFAULTS.default_vpc_vni
-        logger.info("The current vpc is {}".format(vpc.name))
-        if vpc.name == OBJ_DEFAULTS.default_ep_vpc1:
-            vpc.set_vni(OBJ_DEFAULTS.default_vpc_vni1)
-        else:
+        logger.info("The current vpc is {} and the vni is {}".format(vpc.name, vpc.vni))
+        if vpc.vni is None:
             vpc.set_vni(str(uuid.uuid4().int & (1 << 24)-1))
         logger.info("The updated vni is {}".format(vpc.vni))
     

--- a/mizar/dp/mizar/workflows/vpcs/create.py
+++ b/mizar/dp/mizar/workflows/vpcs/create.py
@@ -42,12 +42,18 @@ class VpcCreate(WorkflowTask):
             logger.info("VpcCreate: VPC not found in store. Creating new VPC object for {}".format(
                 self.param.name))
             v = vpcs_opr.get_vpc_stored_obj(self.param.name, self.param.spec)
-        if len(droplets_opr.store.get_all_droplets()) == 0:
-            self.raise_temporary_error(
-                "Task: {} VPC: {} No droplets available.".format(self.__class__.__name__, v.name))
-        logger.info("VpcCreate VPC IP is {}".format(v.ip))
-        vpcs_opr.allocate_vni(v)
-        vpcs_opr.create_vpc_dividers(v, v.n_dividers)
-        vpcs_opr.set_vpc_provisioned(v)
+        if vpcs_opr.is_vni_duplicated(v):
+            # Set vpc status to error instead of raising errors since the latter does not trigger the workflow in future
+            vpcs_opr.set_vpc_error(v)
+            #self.raise_temporary_error(
+            #        "Task: {} VPC: {} Duplicated vni {}.".format(self.__class__.__name__, v.name, v.vni))
+        else:
+            if len(droplets_opr.store.get_all_droplets()) == 0:
+                self.raise_temporary_error(
+                    "Task: {} VPC: {} No droplets available.".format(self.__class__.__name__, v.name))
+            logger.info("VpcCreate VPC IP is {}".format(v.ip))
+            vpcs_opr.allocate_vni(v)
+            vpcs_opr.create_vpc_dividers(v, v.n_dividers)
+            vpcs_opr.set_vpc_provisioned(v)
         vpcs_opr.store_update(v)
         self.finalize()

--- a/mizar/dp/mizar/workflows/vpcs/create.py
+++ b/mizar/dp/mizar/workflows/vpcs/create.py
@@ -45,8 +45,6 @@ class VpcCreate(WorkflowTask):
         if vpcs_opr.is_vni_duplicated(v):
             # Set vpc status to error instead of raising errors since the latter does not trigger the workflow in future
             vpcs_opr.set_vpc_error(v)
-            #self.raise_temporary_error(
-            #        "Task: {} VPC: {} Duplicated vni {}.".format(self.__class__.__name__, v.name, v.vni))
         else:
             if len(droplets_opr.store.get_all_droplets()) == 0:
                 self.raise_temporary_error(

--- a/mizar/obj/tests/test_vpc_with_dup_vni.yaml
+++ b/mizar/obj/tests/test_vpc_with_dup_vni.yaml
@@ -1,0 +1,10 @@
+apiVersion: mizar.com/v1
+kind: Vpc
+metadata:
+  name: vpc11
+spec:
+  vni: 10
+  ip: "192.168.11.0"
+  prefix: "24"
+  dividers: 1
+  status: "Init"

--- a/mizar/obj/tests/test_vpc_with_no_vni.yaml
+++ b/mizar/obj/tests/test_vpc_with_no_vni.yaml
@@ -1,0 +1,9 @@
+apiVersion: mizar.com/v1
+kind: Vpc
+metadata:
+  name: vpc12
+spec:
+  ip: "192.168.12.0"
+  prefix: "24"
+  dividers: 1
+  status: "Init"

--- a/mizar/obj/tests/test_vpc_with_vni.yaml
+++ b/mizar/obj/tests/test_vpc_with_vni.yaml
@@ -1,0 +1,10 @@
+apiVersion: mizar.com/v1
+kind: Vpc
+metadata:
+  name: vpc10
+spec:
+  vni: 10
+  ip: "192.168.10.0"
+  prefix: "24"
+  dividers: 1
+  status: "Init"


### PR DESCRIPTION
The PR is to enable vni settings using yaml files to create vpcs. 
If you don't have any vni settings, it will have a random vni set as usual. 
If there is duplicated vni, the vpc status will be updated to Error.

1. Run the following command to create a vpc with customized vni.  
```bash
kubectl apply -f mizar/obj/tests/test_vpc_with_vni.yaml
```
And you will get the following vpc with vni 10
```bash
ubuntu@ip-172-30-0-62:~/mizar$ kubectl get vpcs vpc10
NAME    IP             PREFIX   VNI   DIVIDERS   STATUS        CREATETIME   PROVISIONDELAY
vpc10   192.168.10.0   24       10    1          Provisioned
```

2. Run the following command to create a vpc with a duplicated vni.  
```bash
kubectl apply -f mizar/obj/tests/test_vpc_with_dup_vni.yaml
```
And you will get the following vpc whose status is Error
```bash
ubuntu@ip-172-30-0-62:~/mizar$ kubectl get vpcs vpc11
NAME    IP             PREFIX   VNI   DIVIDERS   STATUS   CREATETIME   PROVISIONDELAY
vpc11   192.168.11.0   24       10    1          Error
```

3. Run the following command to create a vpc without vni 
```bash
kubectl apply -f mizar/obj/tests/test_vpc_with_no_vni.yaml
```
And you will get the following vpc whose vni has been set to a random number
```bash
ubuntu@ip-172-30-0-62:~/mizar$ kubectl get vpcs vpc12
NAME    IP             PREFIX   VNI       DIVIDERS   STATUS        CREATETIME   PROVISIONDELAY
vpc12   192.168.10.0   24       2771449   1          Provisioned

```